### PR TITLE
 Bug fix to AFSAuth (when called via Launchd)

### DIFF
--- a/SharedProcessors/AFSAuth.py
+++ b/SharedProcessors/AFSAuth.py
@@ -28,7 +28,7 @@ class AFSAuth(Processor):
 				
 			       },
 		'aklog_path': {
-				 'description': 'Path to aklog binary'
+				 'description': 'Path to aklog binary',
 				 'required': False,
 				 'default': '/usr/local/bin/aklog',
 			       },

--- a/SharedProcessors/AFSAuth.py
+++ b/SharedProcessors/AFSAuth.py
@@ -72,9 +72,7 @@ class AFSAuth(Processor):
 	def main(self):
 		auth_method = self.env['auth_method']
                 if auth_method != 'keytab':
-                    raise
-                       ProcessorError('Unsupported authentication method: %s'
-                                       % (auth_method) )
+                    raise ProcessorError('Unsupported authentication method: %s' % (auth_method) )
 		self.gettoken()
 
 if __name__ == '__main__':

--- a/SharedProcessors/AFSAuth.py
+++ b/SharedProcessors/AFSAuth.py
@@ -24,7 +24,13 @@ class AFSAuth(Processor):
 		'auth_method': {
 				 'description': 'keytab is the only option atm',
 				 'required': False,
+				 'default': 'keytab',
 				
+			       },
+		'aklog_path': {
+				 'description': 'Path to aklog binary'
+				 'required': False,
+				 'default': '/usr/local/bin/aklog',
 			       },
 	}
 
@@ -40,10 +46,35 @@ class AFSAuth(Processor):
 		keytabname = os.environ.get("KEYTABNAME", None)
 		principal = os.environ.get("PRINCIPAL",None)
 
-		subprocess.call(["kinit","-t",keytabname,principal])
-		subprocess.call(["aklog"])
+                if keytabname is None:
+                    raise ProcessorError('Missing keytab environment variable')
+
+                self.output('Using Keytab %s with principal %s'
+                              % (keytabname, principal), verbose_level=3)
+
+                self.output('Calling kinit ...', verbose_level=5)
+
+                try:
+		    subprocess.call(["kinit","-t",keytabname,principal])
+                except Exception as kiniterror:
+                    raise ProcessorError('Problem running kinit %s' % kiniterror)
+
+                aklog = self.env['aklog_path']
+                if aklog is None:
+                    raise ProcessorError('Missing aklog_path setting')
+
+                self.output('Calling aklog %s ...' % aklog, verbose_level=5 )
+                try:
+		    subprocess.call([ aklog ])
+                except Exception as aklogerror:
+                    raise ProcessorError('Problem running aklog %s' % aklogerror)
 	
 	def main(self):
+		auth_method = self.env['auth_method']
+                if auth_method != 'keytab':
+                    raise
+                       ProcessorError('Unsupported authentication method: %s'
+                                       % (auth_method) )
 		self.gettoken()
 
 if __name__ == '__main__':

--- a/SharedProcessors/README.md
+++ b/SharedProcessors/README.md
@@ -7,6 +7,10 @@
 The AFSAuth prcoessor performs AFS authentication by obtaining an AFS token.
 This function is performed by spawning shell processes.
 
+There are two optional input variables:
+*`auth_method`: the authentication method, defaulting to the only supported option keytab
+*`aklog_path`: the path to aklog, default /usr/local/bin/aklog
+
 In order to prevent the need of multiple overrides in development environments the following environment variables need to be set:
 * KEYTABNAME
 * PRINCIPAL


### PR DESCRIPTION
 Bug fix to AFSAuth

When called via Launchd, the subprocess call to aklog was exiting with
the error:
     Error: [Errno 2] No such file or directory
which was due the the binary being in `/usr/local/bin` and the path not
being set appropriately.

This commit fixes by adding an option of aklog_path (defaulting to the
above), along with some debugging output when called with a suitable
verbosity (which helped to trace the source of the error).
