### PR TITLE
Recipes for the fuzz type-checker for Z

### DIFF
--- a/fuzz/BuildScriptRunner.py
+++ b/fuzz/BuildScriptRunner.py
@@ -1,0 +1,37 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+#
+# Copyright © University of Oxford
+# Author
+# Name: Ian Collier
+# Email: imc at cs.ox.ac.uk
+# GitHub: imc0
+
+"""
+Run a build script for a package that has already been unpacked
+in order to compile or gather the files that should be placed into
+the eventual package.
+"""
+
+import subprocess
+from autopkglib import Processor, ProcessorError
+
+__all__ = ["BuildScriptRunner"]
+
+class BuildScriptRunner(Processor):
+  input_variables = {
+    'script': {
+      'description': 'Shell commands to run',
+      'required': True,
+    },
+  }
+
+  output_variables = { }
+
+  def main(self):
+    script = self.env['script']
+    rc = subprocess.call(["/bin/bash", "-c", script]);
+    if rc != 0:
+      raise ProcessorError('The build subprocess exited with code ' + str(rc))
+

--- a/fuzz/fuzz.download.recipe
+++ b/fuzz/fuzz.download.recipe
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Attribution</key>
+  <dict>
+    <key>Copyright</key>
+    <string>University of Oxford 2016</string>
+    <key>Author</key>
+    <dict>
+      <key>Name</key>
+      <string>Ian Collier</string>
+      <key>Email</key>
+      <string>ian.collier at cs.ox.ac.uk</string>
+      <key>Github</key>
+      <string>imc0</string>
+    </dict>
+  </dict>
+  <key>Description</key>
+  <string>Downloads the current tarball of the fuzz type-checker</string>
+  <key>Identifier</key>
+  <string>uk.ac.ox.orchard.download.fuzz</string>
+  <key>Input</key>
+  <dict>
+    <key>NAME</key>
+    <string>fuzz</string>
+    <key>BASE_URL</key>
+    <string>http://spivey.oriel.ox.ac.uk/mike/fuzz/</string>
+    <key>SEARCH_PATTERN</key>
+    <string>&lt;A HREF="(?P&lt;filename&gt;[a-z]+-(?P&lt;version&gt;[0-9.]+)\.tgz)"</string>
+  </dict>
+  <key>MinimumVersion</key>
+  <string>0.2.9</string>
+  <key>Process</key>
+  <array>
+    <dict>
+      <key>Processor</key>
+      <string>URLTextSearcher</string>
+      <key>Arguments</key>
+      <dict>
+        <key>re_flags</key>
+        <array>
+          <string>IGNORECASE</string>
+        </array>
+        <key>url</key>
+        <string>%BASE_URL%</string>
+        <key>re_pattern</key>
+        <string>%SEARCH_PATTERN%</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>Processor</key>
+      <string>URLDownloader</string>
+      <key>Arguments</key>
+      <dict>
+        <key>url</key>
+        <string>%BASE_URL%%filename%</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>Processor</key>
+      <string>EndOfCheckPhase</string>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/fuzz/fuzz.munki.recipe
+++ b/fuzz/fuzz.munki.recipe
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/
+PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Attribution</key>
+  <dict>
+    <key>Copyright</key>
+    <string>University of Oxford 2016</string>
+    <key>Author</key>
+    <dict>
+      <key>Name</key>
+      <string>Ian Collier</string>
+      <key>Email</key>
+      <string>ian.collier at cs.ox.ac.uk</string>
+      <key>Github</key>
+      <string>imc0</string>
+    </dict>
+  </dict>
+  <key>Description</key>
+  <string>Imports the current release version of fuzz type checker into Munki</string>
+  <key>Identifier</key>
+  <string>uk.ac.ox.orchard.munki.fuzz</string>
+  <key>Input</key>
+  <dict>
+    <key>NAME</key>
+    <string>fuzz</string>
+    <key>MUNKI_REPO_SUBDIR</key>
+    <string>%NAME%</string>
+    <key>DISPLAY_NAME</key>
+    <string>fuzz type-checker</string>
+    <key>pkginfo</key>
+    <dict>
+      <key>catalogs</key>
+      <array>
+        <string>testing</string>
+      </array>
+      <key>name</key>
+      <string>%NAME%</string>
+      <key>unattended_install</key>
+      <true/>
+      <key>developer</key>
+      <string>Mike Spivey</string>
+      <key>display_name</key>
+      <string>%DISPLAY_NAME%</string>
+      <key>category</key>
+      <string>Software Development</string>
+      <key>description</key>
+      <string>The fuzz type-checker is a suite containing a LaTeX style for typesetting specifications written in the Z ("zed") formal specification language and a tool to check them for compliance with the Z scope and type rules.</string>
+    </dict>
+  </dict>
+  <key>ParentRecipe</key>
+  <string>uk.ac.ox.orchard.pkg.fuzz</string>
+  <key>Process</key>
+  <array>
+    <dict>
+      <key>Processor</key>
+      <string>MunkiPkginfoMerger</string>
+      <key>Arguments</key>
+      <dict>
+        <key>additional_pkginfo</key>
+        <dict>
+          <key>version</key>
+          <string>%version%</string>
+          <key>postinstall_script</key>
+          <string>#!/bin/sh
+          ln -sf ../fuzz/bin/fuzz /usr/local/bin
+          if [ -d /usr/local/texlive/texmf-local/tex ]; then
+            cd /usr/local/texlive/texmf-local
+            mkdir -p tex/latex/local
+            ln -sf ../../../../../fuzz/texmf/tex/fuzz.sty tex/latex/local
+            mkdir -p fonts/source/local
+            cd fonts/source/local
+            ln -sf ../../../../../fuzz/texmf/fonts/source/*.mf .
+            /Library/TeX/texbin/texhash
+          fi
+          </string>
+          <key>postuninstall_script</key>
+          <string>#!/bin/sh
+          texmf=/usr/local/texlive/texmf-local
+          for link in /usr/local/bin/fuzz $texmf/tex/latex/local/fuzz.sty $texmf/fonts/source/local/*.mf; do
+            if [ -h "$link" -a ! -e "$link" ]; then rm -f "$link"; fi
+          done
+          if [ -x /Library/TeX/texbin/texhash ]; then /Library/TeX/texbin/texhash; fi
+          </string>
+        </dict>
+      </dict>
+    </dict>
+    <dict>
+      <key>Processor</key>
+      <string>MunkiImporter</string>
+      <key>Arguments</key>
+      <dict>
+        <key>pkg_path</key>
+        <string>%pkg_path%</string>
+        <key>repo_subdirectory</key>
+        <string>%MUNKI_REPO_SUBDIR%</string>
+      </dict>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/fuzz/fuzz.pkg.recipe
+++ b/fuzz/fuzz.pkg.recipe
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple/DTD PLIST 1.0//EN" "http://apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Attribution</key>
+    <dict>
+      <key>Copyright</key>
+      <string>University of Oxford 2016</string>
+      <key>Author</key>
+      <dict>
+        <key>Name</key>
+        <string>Ian Collier</string>
+        <key>Email</key>
+        <string>ian.collier at cs.ox.ac.uk</string>
+        <key>Github</key>
+        <string>imc0</string>
+      </dict>
+    </dict>
+    <key>Description</key>
+    <string>Builds and packages the current version of the fuzz type checker</string>
+    <key>Identifier</key>
+    <string>uk.ac.ox.orchard.pkg.fuzz</string>
+    <key>Input</key>
+    <dict>
+      <key>NAME</key>
+      <string>fuzz</string>
+      <key>DESTDIR</key>
+      <string>usr/local/fuzz</string>
+    </dict>
+    <key>ParentRecipe</key>
+    <string>uk.ac.ox.orchard.download.fuzz</string>
+    <key>Process</key>
+    <array>
+      <dict>
+        <key>Processor</key>
+        <string>PkgRootCreator</string>
+        <key>Arguments</key>
+        <dict>
+          <key>pkgroot</key>
+          <string>%RECIPE_CACHE_DIR%/payload</string>
+          <key>pkgdirs</key>
+          <dict>
+            <key>usr</key>
+            <string>0775</string>
+          </dict>
+        </dict>
+      </dict>
+      <dict>
+        <key>Processor</key>
+        <string>Unarchiver</string>
+        <key>Arguments</key>
+        <dict>
+          <key>destination_path</key>
+          <string>%RECIPE_CACHE_DIR%/build</string>
+          <key>purge_destination</key>
+          <true/>
+        </dict>
+      </dict>
+      <dict>
+        <key>Processor</key>
+        <string>BuildScriptRunner</string>
+        <key>Arguments</key>
+        <dict>
+          <key>script</key>
+          <string>
+          if [ -f %RECIPE_CACHE_DIR%/%NAME%-%version%.pkg ]; then exit 0; fi
+          set -e
+          echo "Building fuzz from source";
+          cd %RECIPE_CACHE_DIR%/build;
+          destdir=/%DESTDIR%;
+          cd fuzz*;
+          perl -i.orig -lpe 's/gawk /awk /g' src/Makefile;
+          perl -i.orig -lpe '$_="/* $_ */" if /EXTERN char \*strncpy/' src/zscan.l;
+          make CPP=/usr/bin/cpp DEFINES="-DDEBUG -DANSI -DASSUME -DPRELUDE=\\\"$destdir/share/fuzzlib\\\"";
+          make test;
+          destdir=%RECIPE_CACHE_DIR%/payload$destdir;
+          echo "Installing fuzz";
+          mkdir -p "$destdir"/{bin,share,texmf/{tex,fonts/source}}
+          make BINDIR="$destdir/bin" LIBDIR="$destdir/share" TEXDIR="$destdir/texmf/tex" MFDIR="$destdir/texmf/fonts/source" install
+          </string>
+        </dict>
+      </dict>
+      <dict>
+        <key>Processor</key>
+        <string>PkgCreator</string>
+        <key>Arguments</key>
+        <dict>
+          <key>pkg_request</key>
+          <dict>
+            <key>pkgroot</key>
+            <string>%pkgroot%</string>
+            <key>pkgdir</key>
+            <string>%RECIPE_CACHE_DIR%</string>
+            <key>pkgname</key>
+            <string>%NAME%-%version%</string>
+            <key>pkgtype</key>
+            <string>flat</string>
+            <key>id</key>
+            <string>uk.ac.ox.orchard.pkg.fuzz</string>
+            <key>version</key>
+            <string>%version%</string>
+            <key>chown</key>
+            <array>
+              <dict>
+                <key>path</key>
+                <string>%DESTDIR%</string>
+                <key>user</key>
+                <string>root</string>
+                <key>group</key>
+                <string>admin</string>
+              </dict>
+            </array>
+          </dict>
+        </dict>
+      </dict>
+    </array>
+  </dict> 
+</plist>
+


### PR DESCRIPTION
This is "fuzz" which is wanted for the course starting 21 November.

There were various ways of going about this... as previously indicated I am building this from source in the packaging script.  It's not that big, so it doesn't take very long.

In addition, I have made the .pkg file keep everything in one directory tree and the post-install script do some symlinks.  It's possible the post-install script should have been bundled with the .pkg rather than added to Munki; alternatively it might be preferred to just distribute the files to their final locations instead of having symlinks.  (However, I didn't want to make this package depend on TeX because
technically the tool works without it.  The down side is that if you install TeX after this then you don't get the TeX-related symlinks.)