### PR TITLE
add flag to FSFileProvider to mangle .dmg and .iso filenames

### DIFF
--- a/SharedProcessors/FSFileProvider.py
+++ b/SharedProcessors/FSFileProvider.py
@@ -35,6 +35,11 @@ class FSFileProvider(Processor):
                 'required': False,
                 'default': 'match',
                 },
+            'mangle_dmg_iso_filenames': {
+                'description': 'Currently, the DmgCopier tries to look inside paths ending .dmg or .iso; setting this flag will change the output filename from file.iso to file.i?o and file.dmg to file.d?g which works around this',
+                'required': False,
+                'default': 'False',
+                },
             }
 
     output_variables = {
@@ -75,10 +80,16 @@ class FSFileProvider(Processor):
         if output_var_name not in groupdict.keys():
             groupdict[output_var_name] = groupmatch
 
+        self.output('Mangle: %s' % self.env['mangle_dmg_iso_filenames'])
         self.output_variables = {}
         for key in groupdict.keys():
             self.env[key] = groupdict[key]
             self.output('Found matching text (%s): %s' % (key, self.env[key], ))
+            if self.env['mangle_dmg_iso_filenames'] == True and key == 'file':
+                self.env[key] = re.sub('iso$', 'i?o', self.env[key], flags=re.I)
+                self.env[key] = re.sub('dmg$', 'd?g', self.env[key], flags=re.I)
+                self.output('Updated: matching text (%s): %s' % (key, self.env[key], ))
+
             self.output_variables[key] = {
                     'description': 'Matched regular expression group'}
 


### PR DESCRIPTION
As of version 1.0.1 the DmgCopier shipped with autopkg will try to look inside filenames ending .dmg and .iso(see autopkg/autopkg#313).

This commit adds a flag that will mangle the filename from file.iso or file.dmg to file.i?o or file.d?g, respectively (as suggested in the related PR autopkg/autopkg#314) which will then mean that DmgCopier will copy the .iso/.dmg file rather than trying to mount it.