### PR TITLE
EditReady sticking plaster

### DIFF
--- a/DivergentMedia/EditReady.munki.recipe
+++ b/DivergentMedia/EditReady.munki.recipe
@@ -56,7 +56,9 @@
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 				<key>dmg_root</key>
-        <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/EditReady.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/EditReady.app</string>
+				<key>dmg_megabytes</key>
+				<string>100</string>
 			</dict>
 			<key>Processor</key>
 			<string>DmgCreator</string>


### PR DESCRIPTION
EditReady build seems to have failed 2 nights in a row with:

```
Error in local.munki.EditReady: Processor: DmgCreator: Error: creation
     of /srv/autopkg/Cache/local.munki.EditReady/EditReady.dmg failed:
     hdiutil: create failed - error -5341
```

Reading around suggests adding -megabytes will fix this (see autopkg/autopkg#87) , so add this
option (setting megabytes 100M for 56M package, just to give some room
for growth).