### PR TITLE
Add a preinstall script to Oxygen to remove the previously installed version

### DIFF
--- a/oXygenXMLEditor/oXygenXMLEditor.munki.recipe
+++ b/oXygenXMLEditor/oXygenXMLEditor.munki.recipe
@@ -46,10 +46,10 @@
         <string>#!/bin/sh
 # New versions of oXygen should not be installed over old versions, so remove
 # the old version first
-if pkgutil --files uk.ac.ox.orchard.pkg.oxygenxmleditor 2>/dev/null | grep -q Applications/Oxygen/
+if pkgutil --files %PKGID% 2>/dev/null | grep -q Applications/Oxygen/
 then
     rm -rf /Applications/Oxygen
-    pkgutil --forget uk.ac.ox.orchard.pkg.oxygenxmleditor
+    pkgutil --forget %PKGID%
 fi
 exit 0
         </string>

--- a/oXygenXMLEditor/oXygenXMLEditor.munki.recipe
+++ b/oXygenXMLEditor/oXygenXMLEditor.munki.recipe
@@ -42,6 +42,17 @@
         <string>Oxygen XML Editor</string>
         <key>name</key>
         <string>%NAME%</string>
+        <key>preinstall_script</key>
+        <string>#!/bin/sh
+# New versions of oXygen should not be installed over old versions, so remove
+# the old version first
+if pkgutil --files uk.ac.ox.orchard.pkg.oxygenxmleditor 2>/dev/null | grep -q Applications/Oxygen/
+then
+    rm -rf /Applications/Oxygen
+    pkgutil --forget uk.ac.ox.orchard.pkg.oxygenxmleditor
+fi
+exit 0
+        </string>
         <key>unattended_install</key>
         <true/>
       </dict>

--- a/oXygenXMLEditor/oXygenXMLEditor.pkg.recipe
+++ b/oXygenXMLEditor/oXygenXMLEditor.pkg.recipe
@@ -22,6 +22,8 @@
     <string>uk.ac.ox.orchard.pkg.oXygenXMLEditor</string>
     <key>Input</key>
     <dict>
+      <key>PKGID</key>
+      <string>uk.ac.ox.orchard.pkg.oxygenxmleditor</string>
     </dict>
     <key>ParentRecipe</key>
     <string>uk.ac.ox.orchard.download.oXygenXMLEditor</string>
@@ -70,7 +72,7 @@
             <key>pkgroot</key>
             <string>%pkgroot%</string>
             <key>id</key>
-            <string>uk.ac.ox.orchard.pkg.oxygenxmleditor</string>
+            <string>%PKGID%</string>
             <key>options</key>
             <string>purge_ds_store</string>
             <key>chown</key>


### PR DESCRIPTION
... because when Oxygen is being upgraded it objects to being installed over the previous version.
As discussed in ticket 10278197.