### PR TITLE
Update FDR to version 4

### DIFF
--- a/FDR/FDR.munki.recipe
+++ b/FDR/FDR.munki.recipe
@@ -48,6 +48,16 @@
       <string>Software Development</string>
       <key>description</key>
       <string>FDR analyses programs written in CSP_M, which combines the operators of Hoare's CSP with a functional programming language. It also has support for analysing timed systems, via tock CSP.</string>
+      <key>preinstall_script</key>
+      <string>#!/bin/sh
+# If upgrading from FDR3 don't leave the old FDR3.app folder lying around
+if pkgutil --files uk.ac.ox.orchard.pkg.FDR 2>/dev/null | grep -q Applications/FDR3\\.app/
+then
+    rm -rf /Applications/FDR3.app
+    pkgutil --forget uk.ac.ox.orchard.pkg.FDR
+fi
+exit 0
+      </string>
     </dict>
   </dict>
   <key>ParentRecipe</key>

--- a/FDR/FDR.munki.recipe
+++ b/FDR/FDR.munki.recipe
@@ -51,10 +51,10 @@
       <key>preinstall_script</key>
       <string>#!/bin/sh
 # If upgrading from FDR3 don't leave the old FDR3.app folder lying around
-if pkgutil --files uk.ac.ox.orchard.pkg.FDR 2>/dev/null | grep -q Applications/FDR3\\.app/
+if pkgutil --files %PKGID% 2>/dev/null | grep -q Applications/FDR3\\.app/
 then
     rm -rf /Applications/FDR3.app
-    pkgutil --forget uk.ac.ox.orchard.pkg.FDR
+    pkgutil --forget %PKGID%
 fi
 exit 0
       </string>

--- a/FDR/FDR.pkg.recipe
+++ b/FDR/FDR.pkg.recipe
@@ -69,7 +69,7 @@
         <key>Arguments</key>
         <dict>
           <key>source_path</key>
-          <string>%RECIPE_CACHE_DIR%/unpack/*</string>
+          <string>%RECIPE_CACHE_DIR%/unpack/%FDRVER%.app</string>
           <key>destination_path</key>
           <string>%pkgroot%/Applications/%FDRVER%.app/</string>
           <key>overwrite</key>

--- a/FDR/FDR.pkg.recipe
+++ b/FDR/FDR.pkg.recipe
@@ -25,7 +25,7 @@
       <key>NAME</key>
       <string>FDR</string>
       <key>FDRVER</key>
-      <string>FDR3</string>
+      <string>FDR4</string>
     </dict>
     <key>ParentRecipe</key>
     <string>uk.ac.ox.orchard.download.FDR</string>

--- a/FDR/FDR.pkg.recipe
+++ b/FDR/FDR.pkg.recipe
@@ -26,6 +26,8 @@
       <string>FDR</string>
       <key>FDRVER</key>
       <string>FDR4</string>
+      <key>PKGID</key>
+      <string>uk.ac.ox.orchard.pkg.FDR</string>
     </dict>
     <key>ParentRecipe</key>
     <string>uk.ac.ox.orchard.download.FDR</string>
@@ -94,7 +96,7 @@
             <key>pkgtype</key>
             <string>flat</string>
             <key>id</key>
-            <string>uk.ac.ox.orchard.pkg.FDR</string>
+            <string>%PKGID%</string>
             <key>version</key>
             <string>%version%</string>
             <key>chown</key>

--- a/FDR/FDR.pkg.recipe
+++ b/FDR/FDR.pkg.recipe
@@ -52,6 +52,8 @@
         <dict>
           <key>destination_path</key>
           <string>%RECIPE_CACHE_DIR%/unpack</string>
+          <key>purge_destination</key>
+          <true/>
         </dict>
       </dict>
       <dict>


### PR DESCRIPTION
The app changed its name from FDR3 to FDR4 so needs a version change in the pkg recipe
and a pre-install script to clean up the old app folder when the package is upgraded.