### PR TITLE
Make regular expression for current version ignore case

### DIFF
--- a/SMLNJ/SMLNJ.download.recipe
+++ b/SMLNJ/SMLNJ.download.recipe
@@ -44,6 +44,8 @@
         <string>%BASE_URL%</string>
         <key>re_pattern</key>
         <string>%SEARCH_PATTERN1%</string>
+        <key>re_flags</key>
+        <string>IGNORECASE</string>
       </dict>
     </dict>
     <dict>


### PR DESCRIPTION
The web page seems to have changed overnight, and the build failed,
not finding the string 'Current release is' as it is now 'current
release is'; update the RE to ignore case