### PR TITLE
Update ErlangURLProvider to only pick .dmg files

### DIFF
--- a/Erlang/ErlangURLProvider.py
+++ b/Erlang/ErlangURLProvider.py
@@ -96,7 +96,15 @@ class ErlangURLProvider(Processor):
                              if package[u'os'] == u'Mac OS X ' + target_os]
 
         if get_version == u'latest':
-            url = DOWNLOAD_BASE_URL + filtered_packages[0][u'path']
+            idx=0
+            # Select the latest *DMG* as this is what the of the recipe
+            # rest expects (and there are .tgz links around)
+            # 
+            while idx < len(filtered_packages):
+                url = DOWNLOAD_BASE_URL + filtered_packages[idx][u'path']
+                if re.match('.+\.dmg$', url):
+                    break
+                idx=idx+1
         else:
             try:
                 url = DOWNLOAD_BASE_URL + (package for package in filtered_packages


### PR DESCRIPTION
The overnight build of Erlang is failing, as it is picking index 0
from the list of Mac OS X 10.10 packages which currently happens to be
a .tgz file, and not the expected .dmg file.

This select breaks the code signature checking, so this patch ensures
we pick the first .dmg file when selecting the latest.