### PR TITLE
Fix regular expression for BlueJ download

### DIFF
--- a/BlueJ/BlueJ.download.recipe
+++ b/BlueJ/BlueJ.download.recipe
@@ -41,7 +41,7 @@
         <key>url</key>
         <string>%BASE_URL%</string>
         <key>re_pattern</key>
-        <string>Version (?P&lt;version&gt;.*),</string>
+        <string>Version (?P&lt;version&gt;.*?),</string>
       </dict>
     </dict>
      <dict>


### PR DESCRIPTION
The Bluej software was advertising the next version as:

    Version 4.1.0, released 23 June 2017 (fixes editor graphics bug, and more)

and the regex we used for the version was left as the default greedy
expression so matched to the second comma, not the first.

This patch makes the regex non-greed so will only match the version to
the first comma