### PR TITLE
Update Ant download to include a user agent string

### DIFF
--- a/Apache/Ant.download.recipe
+++ b/Apache/Ant.download.recipe
@@ -10,6 +10,8 @@
     <dict>
       <key>NAME</key>
       <string>Apache_Ant</string>
+      <key>USER_AGENT</key>
+      <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/603.2.5 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.5</string>
     </dict>
     <key>Process</key>
     <array>
@@ -20,6 +22,11 @@
         <dict>
           <key>url</key>
           <string>http://ant.apache.org/bindownload.cgi</string>
+          <key>request_headers</key>
+          <dict>
+              <key>user-agent</key>
+              <string>%USER_AGENT%</string>
+          </dict>
           <key>re_pattern</key>
           <string>(?P&lt;url&gt;http.+?apache-ant-(?P&lt;version&gt;.+?)-bin.tar.gz)</string>
         </dict>


### PR DESCRIPTION
The behaviour of the Ant download site seems to have changed, with a
curl request to the site now giving a list of mirrors, rather than the
expected HTML.

I've added a user-agent to the download recipe, which seems to resolve
this issue.