### PR TITLE
Fix oXygenXMLEditor download

### DIFF
--- a/oXygenXMLEditor/oXygenXMLEditor.download.recipe
+++ b/oXygenXMLEditor/oXygenXMLEditor.download.recipe
@@ -22,8 +22,10 @@
   <string>uk.ac.ox.orchard.download.oXygenXMLEditor</string>
   <key>Input</key>
   <dict>
+    <key>SITE</key>
+    <string>https://www.oxygenxml.com</string>
     <key>DOWNLOAD_PAGE</key>
-    <string>https://www.oxygenxml.com/xml_editor/download_oxygenxml_editor.html?os=MacOSX</string>
+    <string>%SITE%/xml_editor/download_oxygenxml_editor.html?os=MacOSX</string>
     <key>OSX_MIN_VERSION</key>
     <string>10.8</string>
     <key>NAME</key>
@@ -41,7 +43,7 @@
         <key>url</key>
         <string>%DOWNLOAD_PAGE%</string>
         <key>re_pattern</key>
-        <string><![CDATA[OS X %OSX_MIN_VERSION% and later.+?>Version: (?P<version>[\d\.]+).+?href="(?P<url>http://mirror\.oxygenxml\.com.+?oxygen\.(?P<ext>.+?))"]]></string>
+        <string><![CDATA[OS X %OSX_MIN_VERSION% and later.+?>Version: (?P<version>[\d\.]+).+href="(?P<urlpath>/InstData.+?oxygen\.(?P<ext>.+?))" title="Download".+disk image to mount it.+]]></string>
             <key>re_flags</key>
             <array>
               <string>MULTILINE</string>
@@ -54,6 +56,8 @@
       <string>URLDownloader</string>
       <key>Arguments</key>
       <dict>
+        <key>url</key>
+        <string>%SITE%%urlpath%</string>
         <key>filename</key>
         <string>%NAME%-%version%.%ext%</string>
       </dict>


### PR DESCRIPTION
The download page for the oXygenXMLEditor changed last week, and this
commit fixes (although not too elgantly) the RE to pick out the
file to be downloaded.