### PR TITLE
SMLNJ updates

### DIFF
--- a/SMLNJ/SMLNJ.download.recipe
+++ b/SMLNJ/SMLNJ.download.recipe
@@ -27,7 +27,7 @@
     <key>BASE_URL</key>
     <string>http://www.smlnj.org/</string>
     <key>SEARCH_PATTERN1</key>
-    <string>[Cc]urrent release is .*"(?P&lt;pkgidx&gt;[^"]+)">(?P&lt;version&gt;[0-9.]+)&lt;</string>
+    <string>[Cc]urrent release is .*?"(?P&lt;pkgidx&gt;[^"]+)">(?P&lt;version&gt;[0-9.]+)&lt;</string>
     <key>SEARCH_PATTERN2</key>
     <string>"(?P&lt;pkgurl&gt;http[^"]+\.pkg)"</string>
   </dict>
@@ -44,8 +44,6 @@
         <string>%BASE_URL%</string>
         <key>re_pattern</key>
         <string>%SEARCH_PATTERN1%</string>
-        <key>re_flags</key>
-        <string>IGNORECASE</string>
       </dict>
     </dict>
     <dict>

--- a/SMLNJ/SMLNJ.munki.recipe
+++ b/SMLNJ/SMLNJ.munki.recipe
@@ -63,6 +63,22 @@
         <dict>
           <key>version</key>
           <string>%version%</string>
+          <key>receipts</key>
+          <array>
+            <dict>
+              <key>version</key>
+              <string>%version%</string>
+            </dict>
+          </array>
+          <key>installs</key>
+          <array>
+            <dict>
+              <key>path</key>
+              <string>/usr/local/smlnj/doc/html/readme/%version%-README.html</string>
+              <key>type</key>
+              <string>file</string>
+            </dict>
+          </array>
           <key>postinstall_script</key>
           <string>#!/bin/sh
  cd /usr/local/bin &amp;&amp; ln -sf ../smlnj/bin/* .


### PR DESCRIPTION
(As previously discussed with Ben) SMLNJ has not been updating recently for two reasons:
firstly, the download recipe broke; and secondly, the vendors are not versioning their package
correctly so Munki doesn't know to update it.  This is an attempt to fix that problem.  It was 
tested on a system with v 110.79 installed; managedsoftwareupdate downloaded and installed
v 110.82 and then when running it again it did not try to re-download the same SMLNJ package.