### PR TITLE
Add purge_destination when using Unarchiver

### DIFF
--- a/Protege/Protege.pkg.recipe
+++ b/Protege/Protege.pkg.recipe
@@ -50,6 +50,8 @@
         <dict>
           <key>destination_path</key>
           <string>%RECIPE_CACHE_DIR%/unpack</string>
+          <key>purge_destination</key>
+          <true/>
         </dict>
       </dict>
       <dict>


### PR DESCRIPTION
Purge the destination before unpacking the downloaded zip so that the
packager doesn't pick up earlier versions that may be lying around.