### PR TITLE
Fixed Gradle.download.recipe - file download URL had changed

### DIFF
--- a/Gradle/Gradle.download.recipe
+++ b/Gradle/Gradle.download.recipe
@@ -25,7 +25,7 @@
     <key>NAME</key>
     <string>Gradle</string>
     <key>BASE_URL</key>
-    <string>https://gradle.org/gradle-download/</string>
+    <string>https://services.gradle.org/distributions</string>
     <key>SEARCH_PATTERN</key>
     <string>"([^"]+-(?P&lt;version&gt;[0-9.]+)-all.zip)"&gt;</string>
   </dict>
@@ -50,7 +50,7 @@
       <key>Arguments</key>
       <dict>
         <key>url</key>
-        <string>%match%</string>
+        <string>https://services.gradle.org%match%</string>
       </dict>
     </dict>
     <dict>


### PR DESCRIPTION
Download location had moved to https://services.gradle.org/distributions - updated Gradle.download.recipe to reflect this

Link on page for latest version as returned by URLTextSearcher was just "/distributions/gradle-4.6-all.zip", omitting the first part of the URL. Fixed this by adding it into the 'url' argument for the URLDownloader ie:
```
<string>https://services.gradle.org%match%</string>