### PR TITLE
added required cookie to GanttProject.download.recipe

### DIFF
--- a/GanttProject/GanttProject.download.recipe
+++ b/GanttProject/GanttProject.download.recipe
@@ -14,6 +14,8 @@
         <string>http://www.ganttproject.biz</string>
         <key>SEARCH_URL</key>
         <string>%BASE_URL%/download/free</string>
+        <key>SEARCH_URL_COOKIE</key>
+        <string>download-visited=y</string>
         <key>SEARCH_PATTERN</key>
         <string>(?P&lt;url&gt;/dl/(?P&lt;version&gt;.*?)/mac)</string>
         <key>USER_AGENT</key>
@@ -32,6 +34,11 @@
           <string>%SEARCH_URL%</string>
           <key>re_pattern</key>
           <string>%SEARCH_PATTERN%</string>
+          <key>request_headers</key>
+          <dict>
+            <key>Cookie</key>
+            <string>%SEARCH_URL_COOKIE%</string>
+          </dict>
         </dict>
       </dict>
         <dict>


### PR DESCRIPTION
Access to http://www.ganttproject.bix/download/free requires a cookie provided by http://www.ganttproject.bix/download. The recipe now includes the cookie settings ("download-visited=y")