### PR TITLE
Fix SMLNJ download recipe

### DIFF
--- a/SMLNJ/SMLNJ.download.recipe
+++ b/SMLNJ/SMLNJ.download.recipe
@@ -5,7 +5,7 @@
   <key>Attribution</key>
   <dict>
     <key>Copyright</key>
-    <string>University of Oxford 2016</string>
+    <string>University of Oxford 2020</string>
     <key>Author</key>
     <dict>
       <key>Name</key>
@@ -27,9 +27,9 @@
     <key>BASE_URL</key>
     <string>http://www.smlnj.org/</string>
     <key>SEARCH_PATTERN1</key>
-    <string>[Cc]urrent release is .*?"(?P&lt;pkgidx&gt;[^"]+)">(?P&lt;version&gt;[0-9.]+)&lt;</string>
+    <string>release is .*?"(?P&lt;pkgidx&gt;[^"]+)">(?P&lt;version&gt;[0-9.]+)&lt;</string>
     <key>SEARCH_PATTERN2</key>
-    <string>"(?P&lt;pkgurl&gt;http[^"]+\.pkg)"</string>
+    <string>"(?P&lt;pkgurl&gt;http[^"]+amd64[^"]+\.pkg)"</string>
   </dict>
   <key>MinimumVersion</key>
   <string>0.2.9</string>


### PR DESCRIPTION
SMLNJ download broke because the ever changing website page changed again.  So we'll remove the word "current" from the search.

There are now two downloads for Mac: the 32-bit and the 64-bit one.  This recipe will select the 64-bit download (previously there was only the 32-bit download).  Please let me know if the change of architecture might present a problem.