### PR TITLE
Update SceneBuilder recipes

### DIFF
--- a/SceneBuilder/SceneBuilder.download.recipe
+++ b/SceneBuilder/SceneBuilder.download.recipe
@@ -5,7 +5,7 @@
   <key>Attribution</key>
   <dict>
     <key>Copyright</key>
-    <string>University of Oxford 2019</string>
+    <string>University of Oxford 2022</string>
     <key>Author</key>
     <dict>
       <key>Name</key>
@@ -24,22 +24,17 @@
   <dict>
     <key>NAME</key>
     <string>SceneBuilder</string>
+    <key>ARCH</key><!-- x86_64 or arm64 -->
+    <string>arm64</string>
+    <key>ARCHTEXT</key><!-- Intel or Apple Silicon -->
+    <string>Apple Silicon</string>
     <key>BASE_URL</key>
     <string>https://gluonhq.com/products/scene-builder/</string>
-    <key>DOWNLOAD_URL</key>
-    <string>https://gluonhq.com/</string>
     <key>SEARCH_PATTERN</key>
-    <string>The latest version .*? is &lt;strong&gt;(?P&lt;version&gt;[0-9.]+)&lt;.*?Mac OS.*?dl=(?P&lt;dlpath&gt;/.*?)"</string>
+    <string>Scene Builder &lt;strong&gt;(?P&lt;version&gt;[0-9.]+)&lt;.*?Mac OS.*?%ARCHTEXT%.*?dl=(?P&lt;dlpath&gt;.*?)"</string>
   </dict>
   <key>MinimumVersion</key>
   <string>0.2.9</string>
-  <!-- Download process: the link on the page is
-       https://gluonhq.com/products/scene-builder/thanks/?dl=/download/scene-builder-VER-mac/
-       which uses JavaScript to redirect the client to a URL which is
-       https://gluonhq.com plus whatever was in the dl parameter. This is then
-       a redirect to the real location.  Because it's a redirect, we have to
-       tell curl what name to save the file as.
-   -->
   <key>Process</key>
   <array>
     <dict>
@@ -63,9 +58,7 @@
       <key>Arguments</key>
       <dict>
         <key>url</key>
-        <string>%DOWNLOAD_URL%%dlpath%</string>
-        <key>filename</key>
-        <string>%NAME%-%version%.pkg</string>
+        <string>%dlpath%</string>
       </dict>
     </dict>
     <dict>

--- a/SceneBuilder/SceneBuilder.munki.recipe
+++ b/SceneBuilder/SceneBuilder.munki.recipe
@@ -5,7 +5,7 @@
   <key>Attribution</key>
   <dict>
     <key>Copyright</key>
-    <string>University of Oxford 2016</string>
+    <string>University of Oxford 2022</string>
     <key>Author</key>
     <dict>
       <key>Name</key>
@@ -44,6 +44,10 @@
       <string>%DISPLAY_NAME%</string>
       <key>category</key>
       <string>Software Development</string>
+      <key>supported_architectures</key>
+      <array>
+        <string>%ARCH%</string>
+      </array>
       <key>description</key>
       <string>Scene Builder is a visual layout tool that lets users quickly design JavaFX application user interfaces without coding. Users can drag and drop UI components to a work area, modify their properties, apply style sheets, and the FXML code for the layout that they are creating is automatically generated in the background.</string>
     </dict>
@@ -52,18 +56,6 @@
   <string>uk.ac.ox.orchard.download.SceneBuilder</string>
   <key>Process</key>
   <array>
-    <dict>
-      <key>Processor</key>
-      <string>MunkiPkginfoMerger</string>
-      <key>Arguments</key>
-      <dict>
-        <key>additional_pkginfo</key>
-        <dict>
-          <key>version</key>
-          <string>%version%</string>
-        </dict>
-      </dict>
-    </dict>
     <dict>
       <key>Processor</key>
       <string>MunkiImporter</string>


### PR DESCRIPTION
As discussed in # 11270817, SceneBuilder is currently not updating because the website has changed.  In addition there are now two downloads, one for each architecture.  (The download has also changed from .pkg to .dmg.) This PR updates the download recipe to search for the correct download, and the Munki recipe to specify the architecture.  It also supports two keys which can be overridden to select the architecture (ARCH which is Munki's name for the architecture, and ARCHTEXT which is the website's name for the architecture) and these are set to arm64/Apple Silicon by default.  Note: this means that Munki's name for the package is the same for each architecture (so it will append __1 to the name of whichever one runs second; but if we make an override to select the other arch then it might also change the name).  Please let me know if you'd prefer to do this a different way.